### PR TITLE
Force ipv4 resolution.

### DIFF
--- a/templates/traas.yaml
+++ b/templates/traas.yaml
@@ -165,6 +165,7 @@ resources:
     properties:
       type: string
       value: |
+        echo "ip_resolve=4" >> /etc/yum.conf
         rpm -q git || yum -y install git
         git clone https://git.openstack.org/openstack-infra/tripleo-ci
         export HOME=/root


### PR DESCRIPTION
Traas is failing to spawn when
resolving IPv6 addresses. This
patch forces the use of IPv4
addresses in yum.